### PR TITLE
cnp-1103-Add Dockerfile optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 FROM openjdk:8-alpine
+ENV WORKDIR /opt/app
+WORKDIR ${WORKDIR}
 
-RUN mkdir -p /opt/app/
-
-WORKDIR /opt/app
-
-COPY docker/entrypoint.sh /
-COPY src /opt/app/
-COPY build.gradle /opt/app/
-COPY gradle /opt/app/gradle
-COPY gradlew /opt/app/
-
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy= curl --silent --fail http://localhost:4104/health
+COPY src ./
+COPY build.gradle gradlew docker/entrypoint.sh ./
+COPY gradle ./gradle
 
 EXPOSE 4104
-
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Resolves CNP-1103

Hello, this PR adds the following enhancements:

improve the ordering of the docker image build layer
prepare for future ACR cache optimisations.

This is part of a general pipelines optimisations initiative and should not impact the current builds.